### PR TITLE
ファイル監視処理の単体テスト実装 (issue #17)

### DIFF
--- a/MachineLog/src/MachineLog.Collector/Extensions/ServiceCollectionExtensions.cs
+++ b/MachineLog/src/MachineLog.Collector/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using MachineLog.Collector.Models;
+using MachineLog.Collector.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -40,7 +41,14 @@ public static class ServiceCollectionExtensions
   public static IServiceCollection AddCollectorServices(
     this IServiceCollection services)
   {
-    // TODO: 各種サービスの登録を実装
+    // ファイル監視サービスの登録
+    services.AddSingleton<IFileWatcherService, FileWatcherService>();
+
+    // ファイル処理サービスの登録
+    services.AddTransient<IFileProcessorService, FileProcessorService>();
+
+    // バリデーターの登録
+    services.AddTransient<FluentValidation.IValidator<MachineLog.Common.Models.LogEntry>, MachineLog.Common.Validation.LogEntryValidator>();
 
     return services;
   }

--- a/MachineLog/src/MachineLog.Collector/Services/FileProcessorService.cs
+++ b/MachineLog/src/MachineLog.Collector/Services/FileProcessorService.cs
@@ -1,0 +1,233 @@
+using FluentValidation;
+using MachineLog.Collector.Models;
+using MachineLog.Common.Models;
+using MachineLog.Common.Validation;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+namespace MachineLog.Collector.Services;
+
+/// <summary>
+/// ファイル処理サービスの実装
+/// </summary>
+public class FileProcessorService : IFileProcessorService
+{
+  private readonly ILogger<FileProcessorService> _logger;
+  private readonly CollectorConfig _config;
+  private readonly IValidator<LogEntry> _validator;
+  private static readonly JsonSerializerOptions _jsonOptions = new()
+  {
+    PropertyNameCaseInsensitive = true,
+    AllowTrailingCommas = true,
+    ReadCommentHandling = JsonCommentHandling.Skip
+  };
+
+  /// <summary>
+  /// コンストラクタ
+  /// </summary>
+  /// <param name="logger">ロガー</param>
+  /// <param name="config">設定</param>
+  /// <param name="validator">LogEntryバリデータ</param>
+  public FileProcessorService(
+      ILogger<FileProcessorService> logger,
+      IOptions<CollectorConfig> config,
+      IValidator<LogEntry> validator)
+  {
+    _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
+    _validator = validator ?? throw new ArgumentNullException(nameof(validator));
+  }
+
+  /// <summary>
+  /// ファイルを処理します
+  /// </summary>
+  public async Task<FileProcessingResult> ProcessFileAsync(string filePath, CancellationToken cancellationToken = default)
+  {
+    var result = new FileProcessingResult
+    {
+      Success = false,
+      ProcessedRecords = 0,
+      FileSizeBytes = new FileInfo(filePath).Length
+    };
+
+    var stopwatch = Stopwatch.StartNew();
+
+    try
+    {
+      _logger.LogInformation("ファイル処理を開始します: {FilePath}", filePath);
+
+      if (!ShouldProcessFile(filePath))
+      {
+        _logger.LogInformation("ファイルは処理対象外です: {FilePath}", filePath);
+        result.Success = true;
+        return result;
+      }
+
+      var encoding = await DetectEncodingAsync(filePath);
+      var validEntries = new List<LogEntry>();
+      var invalidEntries = new List<(string Line, string Error)>();
+
+      // JSON Lines形式のファイルを1行ずつ読み込んで処理
+      using (var streamReader = new StreamReader(filePath, encoding))
+      {
+        string? line;
+        int lineNumber = 0;
+
+        while ((line = await streamReader.ReadLineAsync(cancellationToken)) != null)
+        {
+          lineNumber++;
+
+          if (string.IsNullOrWhiteSpace(line))
+          {
+            continue;
+          }
+
+          try
+          {
+            var entry = JsonSerializer.Deserialize<LogEntry>(line, _jsonOptions);
+
+            if (entry == null)
+            {
+              invalidEntries.Add((line, "デシリアライズ結果がnullです"));
+              continue;
+            }
+
+            // ソースファイル情報を設定
+            entry.SourceFile = filePath;
+            entry.ProcessedAt = DateTime.UtcNow;
+
+            // バリデーション
+            var validationResult = await _validator.ValidateAsync(entry, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+              var errors = string.Join(", ", validationResult.Errors.Select(e => e.ErrorMessage));
+              invalidEntries.Add((line, errors));
+              continue;
+            }
+
+            validEntries.Add(entry);
+          }
+          catch (JsonException ex)
+          {
+            _logger.LogWarning(ex, "JSON解析エラー（行 {LineNumber}）: {Line}", lineNumber, line);
+            invalidEntries.Add((line, $"JSON解析エラー: {ex.Message}"));
+          }
+          catch (Exception ex)
+          {
+            _logger.LogError(ex, "ファイル処理中にエラーが発生しました（行 {LineNumber}）: {Line}", lineNumber, line);
+            invalidEntries.Add((line, $"処理エラー: {ex.Message}"));
+          }
+        }
+      }
+
+      // 処理結果を設定
+      result.ProcessedRecords = validEntries.Count;
+      result.Success = true;
+
+      _logger.LogInformation(
+          "ファイル処理が完了しました: {FilePath}, 有効レコード: {ValidCount}, 無効レコード: {InvalidCount}",
+          filePath, validEntries.Count, invalidEntries.Count);
+
+      if (invalidEntries.Any())
+      {
+        _logger.LogWarning(
+            "ファイル内に無効なレコードがあります: {FilePath}, 無効レコード数: {InvalidCount}",
+            filePath, invalidEntries.Count);
+      }
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "ファイル処理中に例外が発生しました: {FilePath}", filePath);
+      result.Success = false;
+      result.ErrorMessage = ex.Message;
+      result.Exception = ex;
+    }
+    finally
+    {
+      stopwatch.Stop();
+      result.ProcessingTimeMs = stopwatch.ElapsedMilliseconds;
+    }
+
+    return result;
+  }
+
+  /// <summary>
+  /// ファイルのエンコーディングを検出します
+  /// </summary>
+  public async Task<Encoding> DetectEncodingAsync(string filePath)
+  {
+    // 簡易的なエンコーディング検出
+    // 実際のプロジェクトではより高度な検出ロジックが必要かもしれません
+    try
+    {
+      using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+      // BOMを確認
+      var bom = new byte[4];
+      var read = await fileStream.ReadAsync(bom, 0, 4);
+      fileStream.Position = 0;
+
+      if (read >= 2 && bom[0] == 0xFE && bom[1] == 0xFF)
+      {
+        return Encoding.BigEndianUnicode; // UTF-16 BE
+      }
+      if (read >= 2 && bom[0] == 0xFF && bom[1] == 0xFE)
+      {
+        if (read >= 4 && bom[2] == 0 && bom[3] == 0)
+        {
+          return Encoding.UTF32; // UTF-32 LE
+        }
+        return Encoding.Unicode; // UTF-16 LE
+      }
+      if (read >= 3 && bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF)
+      {
+        return Encoding.UTF8; // UTF-8 with BOM
+      }
+      if (read >= 4 && bom[0] == 0 && bom[1] == 0 && bom[2] == 0xFE && bom[3] == 0xFF)
+      {
+        return Encoding.GetEncoding("utf-32BE"); // UTF-32 BE
+      }
+
+      // BOMがない場合はUTF-8と仮定
+      return Encoding.UTF8;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "エンコーディング検出中にエラーが発生しました: {FilePath}", filePath);
+      return Encoding.UTF8; // デフォルトはUTF-8
+    }
+  }
+
+  /// <summary>
+  /// ファイルをフィルタリングします（処理対象かどうかを判断）
+  /// </summary>
+  public bool ShouldProcessFile(string filePath)
+  {
+    // ファイル拡張子が設定と一致するか確認
+    var extension = Path.GetExtension(filePath).ToLowerInvariant();
+    var fileFilter = _config.FileFilter.ToLowerInvariant();
+
+    // ワイルドカードを処理
+    if (fileFilter.StartsWith("*."))
+    {
+      var allowedExtension = fileFilter.Substring(1);
+      return extension.Equals(allowedExtension, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ファイルサイズが大きすぎないか確認
+    var fileInfo = new FileInfo(filePath);
+    var maxSizeBytes = _config.RetentionPolicy.LargeFileSizeThreshold;
+    if (fileInfo.Length > maxSizeBytes)
+    {
+      _logger.LogWarning(
+          "ファイルサイズが大きすぎます: {FilePath}, サイズ: {FileSize} バイト, 最大サイズ: {MaxSize} バイト",
+          filePath, fileInfo.Length, maxSizeBytes);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/MachineLog/src/MachineLog.Collector/Services/FileWatcherService.cs
+++ b/MachineLog/src/MachineLog.Collector/Services/FileWatcherService.cs
@@ -1,0 +1,251 @@
+using MachineLog.Collector.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
+using System.IO;
+
+namespace MachineLog.Collector.Services;
+
+/// <summary>
+/// ファイル監視サービスの実装
+/// </summary>
+public class FileWatcherService : IFileWatcherService, IDisposable
+{
+  private readonly ILogger<FileWatcherService> _logger;
+  private readonly CollectorConfig _config;
+  private readonly List<FileSystemWatcher> _watchers = new();
+  private readonly ConcurrentDictionary<string, DateTime> _processingFiles = new();
+  private Timer? _stabilityCheckTimer;
+  private bool _isDisposed;
+
+  /// <summary>
+  /// ファイル作成イベント
+  /// </summary>
+  public event EventHandler<FileSystemEventArgs>? FileCreated;
+
+  /// <summary>
+  /// ファイル変更イベント
+  /// </summary>
+  public event EventHandler<FileSystemEventArgs>? FileChanged;
+
+  /// <summary>
+  /// ファイル安定化イベント
+  /// </summary>
+  public event EventHandler<FileSystemEventArgs>? FileStabilized;
+
+  /// <summary>
+  /// コンストラクタ
+  /// </summary>
+  /// <param name="logger">ロガー</param>
+  /// <param name="config">設定</param>
+  public FileWatcherService(
+      ILogger<FileWatcherService> logger,
+      IOptions<CollectorConfig> config)
+  {
+    _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
+  }
+
+  /// <summary>
+  /// ファイル監視を開始します
+  /// </summary>
+  public Task StartAsync(CancellationToken cancellationToken)
+  {
+    _logger.LogInformation("ファイル監視サービスを開始しています...");
+
+    if (_config.MonitoringPaths.Count == 0)
+    {
+      _logger.LogWarning("監視対象のディレクトリが設定されていません");
+      return Task.CompletedTask;
+    }
+
+    foreach (var path in _config.MonitoringPaths)
+    {
+      if (!Directory.Exists(path))
+      {
+        _logger.LogWarning("監視対象のディレクトリが存在しません: {Path}", path);
+        continue;
+      }
+
+      var watcher = new FileSystemWatcher(path)
+      {
+        Filter = _config.FileFilter,
+        NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Size,
+        IncludeSubdirectories = true,
+        EnableRaisingEvents = true
+      };
+
+      watcher.Created += OnFileCreated;
+      watcher.Changed += OnFileChanged;
+
+      _watchers.Add(watcher);
+      _logger.LogInformation("ディレクトリの監視を開始しました: {Path}, フィルター: {Filter}", path, _config.FileFilter);
+    }
+
+    // ファイル安定性チェック用のタイマーを開始
+    _stabilityCheckTimer = new Timer(CheckFileStability, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+
+    return Task.CompletedTask;
+  }
+
+  /// <summary>
+  /// ファイル監視を停止します
+  /// </summary>
+  public Task StopAsync(CancellationToken cancellationToken)
+  {
+    _logger.LogInformation("ファイル監視サービスを停止しています...");
+
+    foreach (var watcher in _watchers)
+    {
+      watcher.EnableRaisingEvents = false;
+      watcher.Created -= OnFileCreated;
+      watcher.Changed -= OnFileChanged;
+      watcher.Dispose();
+    }
+
+    _watchers.Clear();
+    _processingFiles.Clear();
+
+    _stabilityCheckTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+    _stabilityCheckTimer?.Dispose();
+    _stabilityCheckTimer = null;
+
+    return Task.CompletedTask;
+  }
+
+  /// <summary>
+  /// ファイル作成イベントハンドラ
+  /// </summary>
+  private void OnFileCreated(object sender, FileSystemEventArgs e)
+  {
+    _logger.LogDebug("ファイル作成イベントを検出しました: {FilePath}", e.FullPath);
+
+    // ファイルの最終更新時刻を記録
+    _processingFiles[e.FullPath] = DateTime.UtcNow;
+
+    // イベントを発火
+    FileCreated?.Invoke(this, e);
+  }
+
+  /// <summary>
+  /// ファイル変更イベントハンドラ
+  /// </summary>
+  private void OnFileChanged(object sender, FileSystemEventArgs e)
+  {
+    _logger.LogDebug("ファイル変更イベントを検出しました: {FilePath}", e.FullPath);
+
+    // ファイルの最終更新時刻を更新
+    _processingFiles[e.FullPath] = DateTime.UtcNow;
+
+    // イベントを発火
+    FileChanged?.Invoke(this, e);
+  }
+
+  /// <summary>
+  /// ファイルの安定性をチェックするメソッド
+  /// </summary>
+  private void CheckFileStability(object? state)
+  {
+    var now = DateTime.UtcNow;
+    var stabilizationPeriod = TimeSpan.FromSeconds(_config.StabilizationPeriodSeconds);
+    var filesToRemove = new List<string>();
+
+    foreach (var file in _processingFiles)
+    {
+      var lastModified = file.Value;
+      var timeSinceLastModification = now - lastModified;
+
+      if (timeSinceLastModification >= stabilizationPeriod)
+      {
+        try
+        {
+          // ファイルが存在し、アクセス可能かチェック
+          if (IsFileAccessible(file.Key))
+          {
+            _logger.LogDebug("ファイルが安定しました: {FilePath}", file.Key);
+
+            // ファイル安定化イベントを発火
+            FileStabilized?.Invoke(this, new FileSystemEventArgs(
+                WatcherChangeTypes.Changed,
+                Path.GetDirectoryName(file.Key) ?? string.Empty,
+                Path.GetFileName(file.Key)));
+
+            filesToRemove.Add(file.Key);
+          }
+        }
+        catch (Exception ex)
+        {
+          _logger.LogWarning(ex, "ファイルの安定性チェック中にエラーが発生しました: {FilePath}", file.Key);
+        }
+      }
+    }
+
+    // 処理済みのファイルをリストから削除
+    foreach (var file in filesToRemove)
+    {
+      _processingFiles.TryRemove(file, out _);
+    }
+  }
+
+  /// <summary>
+  /// ファイルがアクセス可能かどうかをチェックするメソッド
+  /// </summary>
+  private bool IsFileAccessible(string filePath)
+  {
+    try
+    {
+      // ファイルが存在するかチェック
+      if (!File.Exists(filePath))
+      {
+        return false;
+      }
+
+      // ファイルが読み取り可能かチェック
+      using var stream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+      return true;
+    }
+    catch (IOException)
+    {
+      // ファイルがロックされている場合
+      return false;
+    }
+    catch (Exception ex)
+    {
+      _logger.LogWarning(ex, "ファイルアクセスチェック中にエラーが発生しました: {FilePath}", filePath);
+      return false;
+    }
+  }
+
+  /// <summary>
+  /// リソースを解放します
+  /// </summary>
+  public void Dispose()
+  {
+    Dispose(true);
+    GC.SuppressFinalize(this);
+  }
+
+  /// <summary>
+  /// リソースを解放します
+  /// </summary>
+  protected virtual void Dispose(bool disposing)
+  {
+    if (_isDisposed)
+    {
+      return;
+    }
+
+    if (disposing)
+    {
+      foreach (var watcher in _watchers)
+      {
+        watcher.Dispose();
+      }
+
+      _watchers.Clear();
+      _stabilityCheckTimer?.Dispose();
+    }
+
+    _isDisposed = true;
+  }
+}

--- a/MachineLog/src/MachineLog.Collector/Services/IFileProcessorService.cs
+++ b/MachineLog/src/MachineLog.Collector/Services/IFileProcessorService.cs
@@ -1,0 +1,67 @@
+using System.Text;
+
+namespace MachineLog.Collector.Services;
+
+/// <summary>
+/// ファイル処理サービスのインターフェース
+/// </summary>
+public interface IFileProcessorService
+{
+  /// <summary>
+  /// ファイルを処理します
+  /// </summary>
+  /// <param name="filePath">ファイルパス</param>
+  /// <param name="cancellationToken">キャンセレーショントークン</param>
+  /// <returns>処理結果</returns>
+  Task<FileProcessingResult> ProcessFileAsync(string filePath, CancellationToken cancellationToken = default);
+
+  /// <summary>
+  /// ファイルのエンコーディングを検出します
+  /// </summary>
+  /// <param name="filePath">ファイルパス</param>
+  /// <returns>検出されたエンコーディング</returns>
+  Task<Encoding> DetectEncodingAsync(string filePath);
+
+  /// <summary>
+  /// ファイルをフィルタリングします（処理対象かどうかを判断）
+  /// </summary>
+  /// <param name="filePath">ファイルパス</param>
+  /// <returns>処理対象の場合はtrue</returns>
+  bool ShouldProcessFile(string filePath);
+}
+
+/// <summary>
+/// ファイル処理結果
+/// </summary>
+public class FileProcessingResult
+{
+  /// <summary>
+  /// 処理が成功したかどうか
+  /// </summary>
+  public bool Success { get; set; }
+
+  /// <summary>
+  /// 処理されたレコード数
+  /// </summary>
+  public int ProcessedRecords { get; set; }
+
+  /// <summary>
+  /// エラーメッセージ（エラーがある場合）
+  /// </summary>
+  public string? ErrorMessage { get; set; }
+
+  /// <summary>
+  /// 例外（エラーがある場合）
+  /// </summary>
+  public Exception? Exception { get; set; }
+
+  /// <summary>
+  /// 処理時間（ミリ秒）
+  /// </summary>
+  public long ProcessingTimeMs { get; set; }
+
+  /// <summary>
+  /// ファイルサイズ（バイト）
+  /// </summary>
+  public long FileSizeBytes { get; set; }
+}

--- a/MachineLog/src/MachineLog.Collector/Services/IFileWatcherService.cs
+++ b/MachineLog/src/MachineLog.Collector/Services/IFileWatcherService.cs
@@ -1,0 +1,34 @@
+using System.IO;
+
+namespace MachineLog.Collector.Services;
+
+/// <summary>
+/// ファイル監視サービスのインターフェース
+/// </summary>
+public interface IFileWatcherService
+{
+  /// <summary>
+  /// ファイル監視を開始します
+  /// </summary>
+  Task StartAsync(CancellationToken cancellationToken);
+
+  /// <summary>
+  /// ファイル監視を停止します
+  /// </summary>
+  Task StopAsync(CancellationToken cancellationToken);
+
+  /// <summary>
+  /// ファイル作成イベントが発生したときに呼び出されるイベント
+  /// </summary>
+  event EventHandler<FileSystemEventArgs> FileCreated;
+
+  /// <summary>
+  /// ファイル変更イベントが発生したときに呼び出されるイベント
+  /// </summary>
+  event EventHandler<FileSystemEventArgs> FileChanged;
+
+  /// <summary>
+  /// ファイルが安定した（完全に書き込まれた）ときに呼び出されるイベント
+  /// </summary>
+  event EventHandler<FileSystemEventArgs> FileStabilized;
+}

--- a/MachineLog/src/MachineLog.Common/Models/LogEntry.cs
+++ b/MachineLog/src/MachineLog.Common/Models/LogEntry.cs
@@ -1,0 +1,99 @@
+using System.Text.Json.Serialization;
+
+namespace MachineLog.Common.Models;
+
+/// <summary>
+/// ログエントリを表すクラス
+/// </summary>
+public class LogEntry
+{
+  /// <summary>
+  /// ログID
+  /// </summary>
+  [JsonPropertyName("id")]
+  public string Id { get; set; } = string.Empty;
+
+  /// <summary>
+  /// タイムスタンプ
+  /// </summary>
+  [JsonPropertyName("timestamp")]
+  public DateTime Timestamp { get; set; }
+
+  /// <summary>
+  /// デバイスID
+  /// </summary>
+  [JsonPropertyName("deviceId")]
+  public string DeviceId { get; set; } = string.Empty;
+
+  /// <summary>
+  /// ログレベル
+  /// </summary>
+  [JsonPropertyName("level")]
+  public string Level { get; set; } = string.Empty;
+
+  /// <summary>
+  /// メッセージ
+  /// </summary>
+  [JsonPropertyName("message")]
+  public string Message { get; set; } = string.Empty;
+
+  /// <summary>
+  /// カテゴリ
+  /// </summary>
+  [JsonPropertyName("category")]
+  public string? Category { get; set; }
+
+  /// <summary>
+  /// タグ
+  /// </summary>
+  [JsonPropertyName("tags")]
+  public List<string>? Tags { get; set; }
+
+  /// <summary>
+  /// 追加データ
+  /// </summary>
+  [JsonPropertyName("data")]
+  public Dictionary<string, object>? Data { get; set; }
+
+  /// <summary>
+  /// エラー情報
+  /// </summary>
+  [JsonPropertyName("error")]
+  public ErrorInfo? Error { get; set; }
+
+  /// <summary>
+  /// ソースファイル
+  /// </summary>
+  [JsonPropertyName("sourceFile")]
+  public string? SourceFile { get; set; }
+
+  /// <summary>
+  /// 処理日時
+  /// </summary>
+  [JsonPropertyName("processedAt")]
+  public DateTime? ProcessedAt { get; set; }
+}
+
+/// <summary>
+/// エラー情報を表すクラス
+/// </summary>
+public class ErrorInfo
+{
+  /// <summary>
+  /// エラーコード
+  /// </summary>
+  [JsonPropertyName("code")]
+  public string? Code { get; set; }
+
+  /// <summary>
+  /// エラーメッセージ
+  /// </summary>
+  [JsonPropertyName("message")]
+  public string? Message { get; set; }
+
+  /// <summary>
+  /// スタックトレース
+  /// </summary>
+  [JsonPropertyName("stackTrace")]
+  public string? StackTrace { get; set; }
+}

--- a/MachineLog/src/MachineLog.Common/Validation/LogEntryValidator.cs
+++ b/MachineLog/src/MachineLog.Common/Validation/LogEntryValidator.cs
@@ -1,0 +1,102 @@
+using FluentValidation;
+using MachineLog.Common.Models;
+
+namespace MachineLog.Common.Validation;
+
+/// <summary>
+/// LogEntryのバリデーションルールを定義するクラス
+/// </summary>
+public class LogEntryValidator : AbstractValidator<LogEntry>
+{
+  /// <summary>
+  /// コンストラクタ
+  /// </summary>
+  public LogEntryValidator()
+  {
+    RuleFor(x => x.Id)
+        .NotEmpty().WithMessage("IDは必須です")
+        .MaximumLength(50).WithMessage("IDは50文字以内である必要があります");
+
+    RuleFor(x => x.Timestamp)
+        .NotEmpty().WithMessage("タイムスタンプは必須です")
+        .Must(BeValidTimestamp).WithMessage("タイムスタンプは有効な日時である必要があります");
+
+    RuleFor(x => x.DeviceId)
+        .NotEmpty().WithMessage("デバイスIDは必須です")
+        .MaximumLength(100).WithMessage("デバイスIDは100文字以内である必要があります");
+
+    RuleFor(x => x.Level)
+        .NotEmpty().WithMessage("ログレベルは必須です")
+        .Must(BeValidLogLevel).WithMessage("ログレベルは有効な値である必要があります");
+
+    RuleFor(x => x.Message)
+        .NotEmpty().WithMessage("メッセージは必須です");
+
+    RuleFor(x => x.Category)
+        .MaximumLength(100).WithMessage("カテゴリは100文字以内である必要があります")
+        .When(x => x.Category != null);
+
+    RuleFor(x => x.Tags)
+        .Must(BeValidTags).WithMessage("タグは有効な値である必要があります")
+        .When(x => x.Tags != null && x.Tags.Any());
+
+    RuleFor(x => x.SourceFile)
+        .MaximumLength(500).WithMessage("ソースファイルは500文字以内である必要があります")
+        .When(x => x.SourceFile != null);
+
+    RuleFor(x => x.Error)
+        .SetValidator(new ErrorInfoValidator())
+        .When(x => x.Error != null);
+  }
+
+  /// <summary>
+  /// タイムスタンプが有効かどうかを検証します
+  /// </summary>
+  private bool BeValidTimestamp(DateTime timestamp)
+  {
+    // 未来の日時や、あまりにも過去の日時は無効とする
+    return timestamp > new DateTime(2000, 1, 1) && timestamp <= DateTime.UtcNow.AddDays(1);
+  }
+
+  /// <summary>
+  /// ログレベルが有効かどうかを検証します
+  /// </summary>
+  private bool BeValidLogLevel(string level)
+  {
+    var validLevels = new[] { "trace", "debug", "info", "information", "warn", "warning", "error", "fatal", "critical" };
+    return validLevels.Contains(level.ToLower());
+  }
+
+  /// <summary>
+  /// タグが有効かどうかを検証します
+  /// </summary>
+  private bool BeValidTags(List<string>? tags)
+  {
+    if (tags == null || !tags.Any())
+    {
+      return true;
+    }
+
+    // タグは空でなく、50文字以内であること
+    return tags.All(tag => !string.IsNullOrWhiteSpace(tag) && tag.Length <= 50);
+  }
+}
+
+/// <summary>
+/// ErrorInfoのバリデーションルールを定義するクラス
+/// </summary>
+public class ErrorInfoValidator : AbstractValidator<ErrorInfo>
+{
+  /// <summary>
+  /// コンストラクタ
+  /// </summary>
+  public ErrorInfoValidator()
+  {
+    RuleFor(x => x.Message)
+        .NotEmpty().WithMessage("エラーメッセージは必須です");
+
+    RuleFor(x => x.Code)
+        .MaximumLength(50).WithMessage("エラーコードは50文字以内である必要があります")
+        .When(x => x.Code != null);
+  }
+}

--- a/MachineLog/tests/MachineLog.Collector.Tests/Services/FileProcessorServiceTests.cs
+++ b/MachineLog/tests/MachineLog.Collector.Tests/Services/FileProcessorServiceTests.cs
@@ -1,0 +1,267 @@
+using AutoFixture;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using MachineLog.Collector.Models;
+using MachineLog.Collector.Services;
+using MachineLog.Collector.Tests.TestInfrastructure;
+using MachineLog.Common.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MachineLog.Collector.Tests.Services;
+
+public class FileProcessorServiceTests : UnitTestBase
+{
+  private readonly Mock<ILogger<FileProcessorService>> _loggerMock;
+  private readonly Mock<IOptions<CollectorConfig>> _optionsMock;
+  private readonly Mock<IValidator<LogEntry>> _validatorMock;
+  private readonly CollectorConfig _config;
+  private readonly string _testDirectory;
+
+  public FileProcessorServiceTests(ITestOutputHelper output) : base(output)
+  {
+    _loggerMock = new Mock<ILogger<FileProcessorService>>();
+    _validatorMock = new Mock<IValidator<LogEntry>>();
+
+    _config = new CollectorConfig
+    {
+      FileFilter = "*.jsonl",
+      RetentionPolicy = new RetentionPolicy
+      {
+        LargeFileSizeThreshold = 10 * 1024 * 1024 // 10MB
+      }
+    };
+
+    _optionsMock = new Mock<IOptions<CollectorConfig>>();
+    _optionsMock.Setup(x => x.Value).Returns(_config);
+
+    // テスト用の一時ディレクトリを作成
+    _testDirectory = Path.Combine(Path.GetTempPath(), $"FileProcessorTest_{Guid.NewGuid()}");
+    Directory.CreateDirectory(_testDirectory);
+
+    // デフォルトのバリデーション設定
+    _validatorMock
+        .Setup(v => v.ValidateAsync(It.IsAny<LogEntry>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new ValidationResult());
+  }
+
+  public override void Dispose()
+  {
+    // テスト用ディレクトリの削除
+    try
+    {
+      if (Directory.Exists(_testDirectory))
+      {
+        Directory.Delete(_testDirectory, true);
+      }
+    }
+    catch (Exception ex)
+    {
+      Output.WriteLine($"テストディレクトリの削除中にエラーが発生しました: {ex.Message}");
+    }
+
+    base.Dispose();
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public async Task ProcessFileAsync_WithValidJsonLines_ProcessesSuccessfully()
+  {
+    // Arrange
+    var service = new FileProcessorService(_loggerMock.Object, _optionsMock.Object, _validatorMock.Object);
+    var testFilePath = Path.Combine(_testDirectory, "valid.jsonl");
+
+    // 有効なJSONLinesファイルを作成
+    var validEntries = new List<string>
+        {
+            JsonSerializer.Serialize(new LogEntry { Id = "1", DeviceId = "device1", Timestamp = DateTime.UtcNow, Level = "info", Message = "Test message 1" }),
+            JsonSerializer.Serialize(new LogEntry { Id = "2", DeviceId = "device2", Timestamp = DateTime.UtcNow, Level = "error", Message = "Test message 2" })
+        };
+
+    await File.WriteAllLinesAsync(testFilePath, validEntries);
+
+    // Act
+    var result = await service.ProcessFileAsync(testFilePath);
+
+    // Assert
+    result.Should().NotBeNull();
+    result.Success.Should().BeTrue();
+    result.ProcessedRecords.Should().Be(2);
+    result.ErrorMessage.Should().BeNull();
+    result.Exception.Should().BeNull();
+
+    _validatorMock.Verify(
+        v => v.ValidateAsync(It.IsAny<LogEntry>(), It.IsAny<CancellationToken>()),
+        Times.Exactly(2));
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public async Task ProcessFileAsync_WithInvalidJson_ReturnsPartialSuccess()
+  {
+    // Arrange
+    var service = new FileProcessorService(_loggerMock.Object, _optionsMock.Object, _validatorMock.Object);
+    var testFilePath = Path.Combine(_testDirectory, "mixed.jsonl");
+
+    // 有効なJSONと無効なJSONが混在するファイルを作成
+    var entries = new List<string>
+        {
+            JsonSerializer.Serialize(new LogEntry { Id = "1", DeviceId = "device1", Timestamp = DateTime.UtcNow, Level = "info", Message = "Valid entry" }),
+            "{ This is not a valid JSON }",
+            JsonSerializer.Serialize(new LogEntry { Id = "2", DeviceId = "device2", Timestamp = DateTime.UtcNow, Level = "error", Message = "Another valid entry" })
+        };
+
+    await File.WriteAllLinesAsync(testFilePath, entries);
+
+    // Act
+    var result = await service.ProcessFileAsync(testFilePath);
+
+    // Assert
+    result.Should().NotBeNull();
+    result.Success.Should().BeTrue(); // 処理自体は成功
+    result.ProcessedRecords.Should().Be(2); // 有効なエントリのみカウント
+
+    _validatorMock.Verify(
+        v => v.ValidateAsync(It.IsAny<LogEntry>(), It.IsAny<CancellationToken>()),
+        Times.Exactly(2)); // 有効なエントリのみバリデーション
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public async Task ProcessFileAsync_WithValidationErrors_FiltersInvalidEntries()
+  {
+    // Arrange
+    var service = new FileProcessorService(_loggerMock.Object, _optionsMock.Object, _validatorMock.Object);
+    var testFilePath = Path.Combine(_testDirectory, "validation_errors.jsonl");
+
+    // バリデーションエラーを設定
+    _validatorMock.Reset();
+    _validatorMock
+        .Setup(v => v.ValidateAsync(It.Is<LogEntry>(e => e.Id == "1"), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new ValidationResult()); // 有効
+
+    _validatorMock
+        .Setup(v => v.ValidateAsync(It.Is<LogEntry>(e => e.Id == "2"), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new ValidationResult(new[] { new ValidationFailure("DeviceId", "DeviceId is required") })); // 無効
+
+    _validatorMock
+        .Setup(v => v.ValidateAsync(It.Is<LogEntry>(e => e.Id == "3"), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new ValidationResult()); // 有効
+
+    // テストファイルを作成
+    var entries = new List<string>
+        {
+            JsonSerializer.Serialize(new LogEntry { Id = "1", DeviceId = "device1", Timestamp = DateTime.UtcNow, Level = "info", Message = "Valid entry" }),
+            JsonSerializer.Serialize(new LogEntry { Id = "2", DeviceId = "", Timestamp = DateTime.UtcNow, Level = "error", Message = "Invalid entry" }),
+            JsonSerializer.Serialize(new LogEntry { Id = "3", DeviceId = "device3", Timestamp = DateTime.UtcNow, Level = "warn", Message = "Another valid entry" })
+        };
+
+    await File.WriteAllLinesAsync(testFilePath, entries);
+
+    // Act
+    var result = await service.ProcessFileAsync(testFilePath);
+
+    // Assert
+    result.Should().NotBeNull();
+    result.Success.Should().BeTrue();
+    result.ProcessedRecords.Should().Be(2); // 有効なエントリのみカウント
+
+    _validatorMock.Verify(
+        v => v.ValidateAsync(It.IsAny<LogEntry>(), It.IsAny<CancellationToken>()),
+        Times.Exactly(3)); // すべてのエントリがバリデーションされる
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public async Task DetectEncodingAsync_WithUtf8File_ReturnsUtf8Encoding()
+  {
+    // Arrange
+    var service = new FileProcessorService(_loggerMock.Object, _optionsMock.Object, _validatorMock.Object);
+    var testFilePath = Path.Combine(_testDirectory, "utf8.txt");
+
+    // UTF-8ファイルを作成
+    await File.WriteAllTextAsync(testFilePath, "UTF-8テキスト", Encoding.UTF8);
+
+    // Act
+    var result = await service.DetectEncodingAsync(testFilePath);
+
+    // Assert
+    result.Should().NotBeNull();
+    result.WebName.Should().Be("utf-8");
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public async Task DetectEncodingAsync_WithUtf8BomFile_ReturnsUtf8Encoding()
+  {
+    // Arrange
+    var service = new FileProcessorService(_loggerMock.Object, _optionsMock.Object, _validatorMock.Object);
+    var testFilePath = Path.Combine(_testDirectory, "utf8bom.txt");
+
+    // UTF-8 with BOMファイルを作成
+    await File.WriteAllTextAsync(testFilePath, "UTF-8 BOMテキスト", new UTF8Encoding(true));
+
+    // Act
+    var result = await service.DetectEncodingAsync(testFilePath);
+
+    // Assert
+    result.Should().NotBeNull();
+    result.WebName.Should().Be("utf-8");
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public void ShouldProcessFile_WithMatchingExtension_ReturnsTrue()
+  {
+    // Arrange
+    var service = new FileProcessorService(_loggerMock.Object, _optionsMock.Object, _validatorMock.Object);
+    var testFilePath = Path.Combine(_testDirectory, "test.jsonl");
+    File.WriteAllText(testFilePath, "{}");
+
+    // Act
+    var result = service.ShouldProcessFile(testFilePath);
+
+    // Assert
+    result.Should().BeTrue();
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public void ShouldProcessFile_WithNonMatchingExtension_ReturnsFalse()
+  {
+    // Arrange
+    var service = new FileProcessorService(_loggerMock.Object, _optionsMock.Object, _validatorMock.Object);
+    var testFilePath = Path.Combine(_testDirectory, "test.txt");
+    File.WriteAllText(testFilePath, "text content");
+
+    // Act
+    var result = service.ShouldProcessFile(testFilePath);
+
+    // Assert
+    result.Should().BeFalse();
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public void ShouldProcessFile_WithLargeFile_ReturnsFalse()
+  {
+    // Arrange
+    _config.RetentionPolicy.LargeFileSizeThreshold = 10; // 10バイト
+    var service = new FileProcessorService(_loggerMock.Object, _optionsMock.Object, _validatorMock.Object);
+    var testFilePath = Path.Combine(_testDirectory, "large.jsonl");
+    File.WriteAllText(testFilePath, "This is more than 10 bytes");
+
+    // Act
+    var result = service.ShouldProcessFile(testFilePath);
+
+    // Assert
+    result.Should().BeFalse();
+  }
+}

--- a/MachineLog/tests/MachineLog.Collector.Tests/Services/FileWatcherServiceTests.cs
+++ b/MachineLog/tests/MachineLog.Collector.Tests/Services/FileWatcherServiceTests.cs
@@ -1,0 +1,305 @@
+using AutoFixture;
+using FluentAssertions;
+using MachineLog.Collector.Models;
+using MachineLog.Collector.Services;
+using MachineLog.Collector.Tests.TestInfrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MachineLog.Collector.Tests.Services;
+
+public class FileWatcherServiceTests : UnitTestBase
+{
+  private readonly Mock<ILogger<FileWatcherService>> _loggerMock;
+  private readonly Mock<IOptions<CollectorConfig>> _optionsMock;
+  private readonly CollectorConfig _config;
+  private readonly string _testDirectory;
+
+  public FileWatcherServiceTests(ITestOutputHelper output) : base(output)
+  {
+    _loggerMock = new Mock<ILogger<FileWatcherService>>();
+    _config = new CollectorConfig
+    {
+      MonitoringPaths = new List<string>(),
+      FileFilter = "*.jsonl",
+      StabilizationPeriodSeconds = 1
+    };
+    _optionsMock = new Mock<IOptions<CollectorConfig>>();
+    _optionsMock.Setup(x => x.Value).Returns(_config);
+
+    // テスト用の一時ディレクトリを作成
+    _testDirectory = Path.Combine(Path.GetTempPath(), $"FileWatcherTest_{Guid.NewGuid()}");
+    Directory.CreateDirectory(_testDirectory);
+    _config.MonitoringPaths.Add(_testDirectory);
+  }
+
+  public override void Dispose()
+  {
+    // テスト用ディレクトリの削除
+    try
+    {
+      if (Directory.Exists(_testDirectory))
+      {
+        Directory.Delete(_testDirectory, true);
+      }
+    }
+    catch (Exception ex)
+    {
+      Output.WriteLine($"テストディレクトリの削除中にエラーが発生しました: {ex.Message}");
+    }
+
+    base.Dispose();
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public async Task StartAsync_WithValidConfig_StartsWatching()
+  {
+    // Arrange
+    var service = new FileWatcherService(_loggerMock.Object, _optionsMock.Object);
+
+    // Act
+    await service.StartAsync(CancellationToken.None);
+
+    // Assert
+    _loggerMock.Verify(
+        x => x.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("ファイル監視サービスを開始")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+        Times.Once);
+
+    // Clean up
+    await service.StopAsync(CancellationToken.None);
+    service.Dispose();
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public async Task StopAsync_AfterStarting_StopsWatching()
+  {
+    // Arrange
+    var service = new FileWatcherService(_loggerMock.Object, _optionsMock.Object);
+    await service.StartAsync(CancellationToken.None);
+
+    // Act
+    await service.StopAsync(CancellationToken.None);
+
+    // Assert
+    _loggerMock.Verify(
+        x => x.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("ファイル監視サービスを停止")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+        Times.Once);
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public async Task FileCreated_WhenFileIsCreated_RaisesEvent()
+  {
+    // Arrange
+    var service = new FileWatcherService(_loggerMock.Object, _optionsMock.Object);
+    var eventRaised = false;
+    var eventPath = string.Empty;
+
+    service.FileCreated += (sender, e) =>
+    {
+      eventRaised = true;
+      eventPath = e.FullPath;
+    };
+
+    await service.StartAsync(CancellationToken.None);
+
+    // テスト用のファイルを作成する前に少し待機
+    await Task.Delay(500);
+
+    // Act
+    var testFilePath = Path.Combine(_testDirectory, $"test_{Guid.NewGuid()}.jsonl");
+    File.WriteAllText(testFilePath, "test content");
+
+    // ファイル作成イベントが発生するまで待機
+    var timeout = TimeSpan.FromSeconds(5);
+    var startTime = DateTime.UtcNow;
+    while (!eventRaised && DateTime.UtcNow - startTime < timeout)
+    {
+      await Task.Delay(100);
+    }
+
+    // Assert
+    eventRaised.Should().BeTrue("ファイル作成イベントが発生するはずです");
+    eventPath.Should().Be(testFilePath);
+
+    // Clean up
+    await service.StopAsync(CancellationToken.None);
+    service.Dispose();
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public async Task FileChanged_WhenFileIsModified_RaisesEvent()
+  {
+    // Arrange
+    var service = new FileWatcherService(_loggerMock.Object, _optionsMock.Object);
+    var eventRaised = false;
+    var eventPath = string.Empty;
+
+    service.FileChanged += (sender, e) =>
+    {
+      eventRaised = true;
+      eventPath = e.FullPath;
+    };
+
+    // テスト用のファイルを事前に作成
+    var testFilePath = Path.Combine(_testDirectory, $"test_{Guid.NewGuid()}.jsonl");
+    File.WriteAllText(testFilePath, "initial content");
+
+    await service.StartAsync(CancellationToken.None);
+
+    // テスト用のファイルを変更する前に少し待機
+    await Task.Delay(500);
+
+    // Act
+    File.AppendAllText(testFilePath, "\nadditional content");
+
+    // ファイル変更イベントが発生するまで待機
+    var timeout = TimeSpan.FromSeconds(5);
+    var startTime = DateTime.UtcNow;
+    while (!eventRaised && DateTime.UtcNow - startTime < timeout)
+    {
+      await Task.Delay(100);
+    }
+
+    // Assert
+    eventRaised.Should().BeTrue("ファイル変更イベントが発生するはずです");
+    eventPath.Should().Be(testFilePath);
+
+    // Clean up
+    await service.StopAsync(CancellationToken.None);
+    service.Dispose();
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public async Task FileStabilized_WhenFileIsStable_RaisesEvent()
+  {
+    // Arrange
+    var service = new FileWatcherService(_loggerMock.Object, _optionsMock.Object);
+    var eventRaised = false;
+    var eventPath = string.Empty;
+
+    service.FileStabilized += (sender, e) =>
+    {
+      eventRaised = true;
+      eventPath = e.FullPath;
+    };
+
+    await service.StartAsync(CancellationToken.None);
+
+    // テスト用のファイルを作成する前に少し待機
+    await Task.Delay(500);
+
+    // Act
+    var testFilePath = Path.Combine(_testDirectory, $"test_{Guid.NewGuid()}.jsonl");
+    File.WriteAllText(testFilePath, "test content");
+
+    // ファイル安定化イベントが発生するまで待機（安定化期間 + 余裕）
+    var timeout = TimeSpan.FromSeconds(_config.StabilizationPeriodSeconds + 3);
+    var startTime = DateTime.UtcNow;
+    while (!eventRaised && DateTime.UtcNow - startTime < timeout)
+    {
+      await Task.Delay(100);
+    }
+
+    // Assert
+    eventRaised.Should().BeTrue("ファイル安定化イベントが発生するはずです");
+    Path.GetFullPath(eventPath).Should().Be(Path.GetFullPath(testFilePath));
+
+    // Clean up
+    await service.StopAsync(CancellationToken.None);
+    service.Dispose();
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public async Task StartAsync_WithMultipleDirectories_WatchesAllDirectories()
+  {
+    // Arrange
+    var secondTestDirectory = Path.Combine(Path.GetTempPath(), $"FileWatcherTest2_{Guid.NewGuid()}");
+    Directory.CreateDirectory(secondTestDirectory);
+    _config.MonitoringPaths.Add(secondTestDirectory);
+
+    var service = new FileWatcherService(_loggerMock.Object, _optionsMock.Object);
+    var firstDirEventRaised = false;
+    var secondDirEventRaised = false;
+    var eventPath = string.Empty;
+
+    service.FileCreated += (sender, e) =>
+    {
+      eventPath = e.FullPath;
+      if (eventPath.StartsWith(_testDirectory))
+      {
+        firstDirEventRaised = true;
+      }
+      else if (eventPath.StartsWith(secondTestDirectory))
+      {
+        secondDirEventRaised = true;
+      }
+    };
+
+    await service.StartAsync(CancellationToken.None);
+
+    // テスト用のファイルを作成する前に少し待機
+    await Task.Delay(500);
+
+    // Act - 最初のディレクトリにファイルを作成
+    var firstFilePath = Path.Combine(_testDirectory, $"test1_{Guid.NewGuid()}.jsonl");
+    File.WriteAllText(firstFilePath, "test content 1");
+
+    // 最初のイベントが発生するまで待機
+    var timeout = TimeSpan.FromSeconds(5);
+    var startTime = DateTime.UtcNow;
+    while (!firstDirEventRaised && DateTime.UtcNow - startTime < timeout)
+    {
+      await Task.Delay(100);
+    }
+
+    // 2番目のディレクトリにファイルを作成
+    var secondFilePath = Path.Combine(secondTestDirectory, $"test2_{Guid.NewGuid()}.jsonl");
+    File.WriteAllText(secondFilePath, "test content 2");
+
+    // 2番目のイベントが発生するまで待機
+    startTime = DateTime.UtcNow;
+    while (!secondDirEventRaised && DateTime.UtcNow - startTime < timeout)
+    {
+      await Task.Delay(100);
+    }
+
+    // Assert
+    firstDirEventRaised.Should().BeTrue("最初のディレクトリのファイル作成イベントが発生するはずです");
+    secondDirEventRaised.Should().BeTrue("2番目のディレクトリのファイル作成イベントが発生するはずです");
+
+    // Clean up
+    await service.StopAsync(CancellationToken.None);
+    service.Dispose();
+    try
+    {
+      if (Directory.Exists(secondTestDirectory))
+      {
+        Directory.Delete(secondTestDirectory, true);
+      }
+    }
+    catch (Exception ex)
+    {
+      Output.WriteLine($"2番目のテストディレクトリの削除中にエラーが発生しました: {ex.Message}");
+    }
+  }
+}

--- a/MachineLog/tests/MachineLog.Collector.Tests/TestInfrastructure/AutoFixtureFactory.cs
+++ b/MachineLog/tests/MachineLog.Collector.Tests/TestInfrastructure/AutoFixtureFactory.cs
@@ -1,0 +1,52 @@
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using AutoFixture.Xunit2;
+
+namespace MachineLog.Collector.Tests.TestInfrastructure;
+
+/// <summary>
+/// AutoFixtureのファクトリークラス
+/// </summary>
+public static class AutoFixtureFactory
+{
+  /// <summary>
+  /// 基本的なAutoFixtureインスタンスを作成
+  /// </summary>
+  public static IFixture Create()
+  {
+    var fixture = new Fixture();
+    fixture.Customize(new AutoMoqCustomization());
+    return fixture;
+  }
+
+  /// <summary>
+  /// カスタマイズされたAutoFixtureインスタンスを作成
+  /// </summary>
+  public static IFixture CreateCustomized(Action<IFixture> customization)
+  {
+    var fixture = Create();
+    customization(fixture);
+    return fixture;
+  }
+
+  /// <summary>
+  /// AutoDataAttributeを作成
+  /// </summary>
+  public static CustomAutoDataAttribute CreateAttribute()
+  {
+    return new CustomAutoDataAttribute(() => Create());
+  }
+
+  /// <summary>
+  /// カスタマイズされたAutoDataAttributeを作成
+  /// </summary>
+  public static CustomAutoDataAttribute CreateCustomizedAttribute(Action<IFixture> customization)
+  {
+    return new CustomAutoDataAttribute(() =>
+    {
+      var fixture = Create();
+      customization(fixture);
+      return fixture;
+    });
+  }
+}

--- a/MachineLog/tests/MachineLog.Collector.Tests/TestInfrastructure/CustomAutoDataAttribute.cs
+++ b/MachineLog/tests/MachineLog.Collector.Tests/TestInfrastructure/CustomAutoDataAttribute.cs
@@ -1,0 +1,18 @@
+using AutoFixture;
+using AutoFixture.Xunit2;
+
+namespace MachineLog.Collector.Tests.TestInfrastructure;
+
+/// <summary>
+/// カスタマイズ可能なAutoDataAttribute
+/// </summary>
+public class CustomAutoDataAttribute : AutoDataAttribute
+{
+  public CustomAutoDataAttribute(Func<IFixture> fixtureFactory) : base(() =>
+  {
+    var fixture = fixtureFactory();
+    return fixture;
+  })
+  {
+  }
+}

--- a/MachineLog/tests/MachineLog.Collector.Tests/TestInfrastructure/TestBase.cs
+++ b/MachineLog/tests/MachineLog.Collector.Tests/TestInfrastructure/TestBase.cs
@@ -1,0 +1,71 @@
+using AutoFixture;
+using FluentAssertions;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MachineLog.Collector.Tests.TestInfrastructure;
+
+/// <summary>
+/// テストクラスの基底クラス
+/// </summary>
+public abstract class TestBase : IDisposable
+{
+  protected readonly IFixture Fixture;
+  protected readonly ITestOutputHelper Output;
+
+  protected TestBase(ITestOutputHelper output)
+  {
+    Output = output;
+    Fixture = AutoFixtureFactory.Create();
+  }
+
+  /// <summary>
+  /// モックの検証を行う
+  /// </summary>
+  protected void VerifyAllMocks(params Mock[] mocks)
+  {
+    foreach (var mock in mocks)
+    {
+      try
+      {
+        mock.VerifyAll();
+      }
+      catch (MockException ex)
+      {
+        Output.WriteLine($"Mock verification failed: {ex.Message}");
+        throw;
+      }
+    }
+  }
+
+  /// <summary>
+  /// テスト実行後のクリーンアップ
+  /// </summary>
+  public virtual void Dispose()
+  {
+    // 継承先でリソースの解放が必要な場合はoverrideして実装
+  }
+}
+
+/// <summary>
+/// 統合テスト用の基底クラス
+/// </summary>
+[Trait("Category", TestCategories.Integration)]
+public abstract class IntegrationTestBase : TestBase
+{
+  protected IntegrationTestBase(ITestOutputHelper output) : base(output)
+  {
+  }
+}
+
+/// <summary>
+/// 単体テスト用の基底クラス
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public abstract class UnitTestBase : TestBase
+{
+  protected UnitTestBase(ITestOutputHelper output) : base(output)
+  {
+  }
+}

--- a/MachineLog/tests/MachineLog.Collector.Tests/TestInfrastructure/TestCategories.cs
+++ b/MachineLog/tests/MachineLog.Collector.Tests/TestInfrastructure/TestCategories.cs
@@ -1,0 +1,15 @@
+namespace MachineLog.Collector.Tests.TestInfrastructure;
+
+/// <summary>
+/// テストカテゴリの定義
+/// </summary>
+public static class TestCategories
+{
+  public const string Unit = "Unit";
+  public const string Integration = "Integration";
+  public const string Performance = "Performance";
+  public const string Security = "Security";
+  public const string DataAccess = "DataAccess";
+  public const string API = "API";
+  public const string UI = "UI";
+}

--- a/MachineLog/tests/MachineLog.Collector.Tests/Validation/LogEntryValidatorTests.cs
+++ b/MachineLog/tests/MachineLog.Collector.Tests/Validation/LogEntryValidatorTests.cs
@@ -1,0 +1,304 @@
+using FluentAssertions;
+using MachineLog.Collector.Tests.TestInfrastructure;
+using MachineLog.Common.Models;
+using MachineLog.Common.Validation;
+using System.Text.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MachineLog.Collector.Tests.Validation;
+
+public class LogEntryValidatorTests : UnitTestBase
+{
+  private readonly LogEntryValidator _validator;
+
+  public LogEntryValidatorTests(ITestOutputHelper output) : base(output)
+  {
+    _validator = new LogEntryValidator();
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public void Validate_WithValidLogEntry_ShouldPass()
+  {
+    // Arrange
+    var logEntry = new LogEntry
+    {
+      Id = "test-id-123",
+      Timestamp = DateTime.UtcNow.AddMinutes(-5),
+      DeviceId = "device-001",
+      Level = "info",
+      Message = "This is a test message",
+      Category = "Test",
+      Tags = new List<string> { "test", "validation" },
+      Data = new Dictionary<string, object> { { "key1", "value1" } }
+    };
+
+    // Act
+    var result = _validator.Validate(logEntry);
+
+    // Assert
+    result.IsValid.Should().BeTrue();
+    result.Errors.Should().BeEmpty();
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public void Validate_WithMissingRequiredFields_ShouldFail()
+  {
+    // Arrange
+    var logEntry = new LogEntry
+    {
+      // Missing Id, Timestamp, DeviceId, Level, Message
+      Category = "Test",
+      Tags = new List<string> { "test" }
+    };
+
+    // Act
+    var result = _validator.Validate(logEntry);
+
+    // Assert
+    result.IsValid.Should().BeFalse();
+    result.Errors.Should().HaveCount(5); // 5つの必須フィールドが欠けている
+
+    result.Errors.Select(e => e.PropertyName).Should().Contain("Id");
+    result.Errors.Select(e => e.PropertyName).Should().Contain("Timestamp");
+    result.Errors.Select(e => e.PropertyName).Should().Contain("DeviceId");
+    result.Errors.Select(e => e.PropertyName).Should().Contain("Level");
+    result.Errors.Select(e => e.PropertyName).Should().Contain("Message");
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public void Validate_WithInvalidTimestamp_ShouldFail()
+  {
+    // Arrange
+    var logEntry = new LogEntry
+    {
+      Id = "test-id-123",
+      Timestamp = DateTime.UtcNow.AddDays(2), // 未来の日時
+      DeviceId = "device-001",
+      Level = "info",
+      Message = "This is a test message"
+    };
+
+    // Act
+    var result = _validator.Validate(logEntry);
+
+    // Assert
+    result.IsValid.Should().BeFalse();
+    result.Errors.Should().ContainSingle();
+    result.Errors[0].PropertyName.Should().Be("Timestamp");
+  }
+
+  [Theory]
+  [InlineData("trace")]
+  [InlineData("debug")]
+  [InlineData("info")]
+  [InlineData("information")]
+  [InlineData("warn")]
+  [InlineData("warning")]
+  [InlineData("error")]
+  [InlineData("fatal")]
+  [InlineData("critical")]
+  [Trait("Category", TestCategories.Unit)]
+  public void Validate_WithValidLogLevel_ShouldPass(string level)
+  {
+    // Arrange
+    var logEntry = new LogEntry
+    {
+      Id = "test-id-123",
+      Timestamp = DateTime.UtcNow.AddMinutes(-5),
+      DeviceId = "device-001",
+      Level = level,
+      Message = "This is a test message"
+    };
+
+    // Act
+    var result = _validator.Validate(logEntry);
+
+    // Assert
+    result.IsValid.Should().BeTrue();
+  }
+
+  [Theory]
+  [InlineData("")]
+  [InlineData("unknown")]
+  [InlineData("log")]
+  [InlineData("severe")]
+  [Trait("Category", TestCategories.Unit)]
+  public void Validate_WithInvalidLogLevel_ShouldFail(string level)
+  {
+    // Arrange
+    var logEntry = new LogEntry
+    {
+      Id = "test-id-123",
+      Timestamp = DateTime.UtcNow.AddMinutes(-5),
+      DeviceId = "device-001",
+      Level = level,
+      Message = "This is a test message"
+    };
+
+    // Act
+    var result = _validator.Validate(logEntry);
+
+    // Assert
+    result.IsValid.Should().BeFalse();
+    result.Errors.Should().ContainSingle();
+    result.Errors[0].PropertyName.Should().Be("Level");
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public void Validate_WithTooLongId_ShouldFail()
+  {
+    // Arrange
+    var logEntry = new LogEntry
+    {
+      Id = new string('a', 51), // 51文字（上限は50文字）
+      Timestamp = DateTime.UtcNow.AddMinutes(-5),
+      DeviceId = "device-001",
+      Level = "info",
+      Message = "This is a test message"
+    };
+
+    // Act
+    var result = _validator.Validate(logEntry);
+
+    // Assert
+    result.IsValid.Should().BeFalse();
+    result.Errors.Should().ContainSingle();
+    result.Errors[0].PropertyName.Should().Be("Id");
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public void Validate_WithTooLongDeviceId_ShouldFail()
+  {
+    // Arrange
+    var logEntry = new LogEntry
+    {
+      Id = "test-id-123",
+      Timestamp = DateTime.UtcNow.AddMinutes(-5),
+      DeviceId = new string('a', 101), // 101文字（上限は100文字）
+      Level = "info",
+      Message = "This is a test message"
+    };
+
+    // Act
+    var result = _validator.Validate(logEntry);
+
+    // Assert
+    result.IsValid.Should().BeFalse();
+    result.Errors.Should().ContainSingle();
+    result.Errors[0].PropertyName.Should().Be("DeviceId");
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public void Validate_WithInvalidTags_ShouldFail()
+  {
+    // Arrange
+    var logEntry = new LogEntry
+    {
+      Id = "test-id-123",
+      Timestamp = DateTime.UtcNow.AddMinutes(-5),
+      DeviceId = "device-001",
+      Level = "info",
+      Message = "This is a test message",
+      Tags = new List<string> { "", new string('a', 51) } // 空のタグと51文字のタグ（上限は50文字）
+    };
+
+    // Act
+    var result = _validator.Validate(logEntry);
+
+    // Assert
+    result.IsValid.Should().BeFalse();
+    result.Errors.Should().ContainSingle();
+    result.Errors[0].PropertyName.Should().Be("Tags");
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public void Validate_WithErrorInfo_ShouldValidateErrorInfo()
+  {
+    // Arrange
+    var logEntry = new LogEntry
+    {
+      Id = "test-id-123",
+      Timestamp = DateTime.UtcNow.AddMinutes(-5),
+      DeviceId = "device-001",
+      Level = "error",
+      Message = "Error occurred",
+      Error = new ErrorInfo
+      {
+        // Message is missing
+        Code = "E001",
+        StackTrace = "at Method() in File.cs:line 10"
+      }
+    };
+
+    // Act
+    var result = _validator.Validate(logEntry);
+
+    // Assert
+    result.IsValid.Should().BeFalse();
+    result.Errors.Should().ContainSingle();
+    result.Errors[0].PropertyName.Should().Be("Error.Message");
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public void Validate_WithValidErrorInfo_ShouldPass()
+  {
+    // Arrange
+    var logEntry = new LogEntry
+    {
+      Id = "test-id-123",
+      Timestamp = DateTime.UtcNow.AddMinutes(-5),
+      DeviceId = "device-001",
+      Level = "error",
+      Message = "Error occurred",
+      Error = new ErrorInfo
+      {
+        Message = "Detailed error message",
+        Code = "E001",
+        StackTrace = "at Method() in File.cs:line 10"
+      }
+    };
+
+    // Act
+    var result = _validator.Validate(logEntry);
+
+    // Assert
+    result.IsValid.Should().BeTrue();
+  }
+
+  [Fact]
+  [Trait("Category", TestCategories.Unit)]
+  public void Validate_WithJsonDeserialization_ShouldValidateCorrectly()
+  {
+    // Arrange
+    var json = @"{
+            ""id"": ""test-id-123"",
+            ""timestamp"": ""2023-01-01T12:00:00Z"",
+            ""deviceId"": ""device-001"",
+            ""level"": ""info"",
+            ""message"": ""This is a test message"",
+            ""category"": ""Test"",
+            ""tags"": [""test"", ""validation""],
+            ""data"": {
+                ""key1"": ""value1"",
+                ""key2"": 123
+            }
+        }";
+
+    var logEntry = JsonSerializer.Deserialize<LogEntry>(json);
+
+    // Act
+    var result = _validator.Validate(logEntry!);
+
+    // Assert
+    result.IsValid.Should().BeTrue();
+  }
+}


### PR DESCRIPTION
## 概要

issue #17 で要求されているファイル監視処理の単体テストを実装しました。

## 実装内容

1. ファイル監視サービス（FileWatcherService）の実装と単体テスト
   - ファイル作成イベントのテスト
   - ファイル変更イベントのテスト
   - ファイル安定性検出のテスト
   - 複数ディレクトリ監視のテスト

2. ファイル処理サービス（FileProcessorService）の実装と単体テスト
   - ファイル読み込み処理のテスト
   - エンコーディング検出のテスト
   - ファイルフィルタリングのテスト
   - エラー処理のテスト
   - JSON解析処理のテスト

3. バリデーションロジック（LogEntryValidator）の実装と単体テスト
   - LogEntryバリデーションのテスト
   - 必須フィールドチェックのテスト
   - データ型変換のテスト
   - エッジケースのテスト

## 受け入れ基準

- [x] すべてのファイル監視イベントが正しくテストされていること
- [x] ファイル処理ロジックが適切にテストされていること
- [x] JSON解析の正常系異常系がテストされていること
- [x] バリデーションロジックが完全にテストされていること

Closes #17