### PR TITLE
MachineLog.Monitor.Clientプロジェクトの修正

### DIFF
--- a/MachineLog/src/MachineLog.Monitor/Client/MachineLog.Monitor.Client.csproj
+++ b/MachineLog/src/MachineLog.Monitor/Client/MachineLog.Monitor.Client.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 修正内容
- MachineLog.Monitor.Clientプロジェクトの設定を修正
  - OutputTypeをLibraryに設定して、エントリーポイントエラーを解消

## 背景
- PR #32のマージ後、ビルドエラーが発生していた問題を修正