### PR TITLE
JsonLineProcessorの最適化 (issue #14)

### DIFF
--- a/.tasks/issue-14
+++ b/.tasks/issue-14
@@ -1,0 +1,9 @@
+# Issue 14: 非機能要件: パフォーマンス最適化
+
+## 2025/3/28 午後8:13
+
+- タスク開始
+- ブランチ `feature/issue-14-performance-optimization` を作成
+- JSONシリアライズ/デシリアライズの最適化に着手
+- `JsonLineProcessor.cs` をリファクタリングし、`System.Text.Json.Utf8JsonReader` を使用するように変更
+- コンパイラエラーを修正

--- a/MachineLog/src/MachineLog.Collector/Services/JsonLineProcessor.cs
+++ b/MachineLog/src/MachineLog.Collector/Services/JsonLineProcessor.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Net; // WebUtility.HtmlEncode を使用するために追加
 using System.Globalization; // CultureInfo を使用するために追加
+using MachineLog.Common.Models; // ErrorInfo を使用するために追加
 
 namespace MachineLog.Collector.Services;
 
@@ -134,7 +135,9 @@ public class JsonLineProcessor
       LineProcessingResult result;
       try
       {
-        var entry = await ProcessLineAsync(line, filePath, lineNumber, cancellationToken).ConfigureAwait(false);
+        // Utf8JsonReader を使用するためにバイト配列に変換
+        var utf8Bytes = Encoding.UTF8.GetBytes(line);
+        var entry = ProcessLine(utf8Bytes, filePath, lineNumber); // 同期メソッド呼び出しに変更
         result = new LineProcessingResult
         {
           IsValid = entry != null,
@@ -185,56 +188,191 @@ public class JsonLineProcessor
   /// <param name="line">処理対象の行</param>
   /// <param name="filePath">ファイルパス（メタデータとして使用）</param>
   /// <param name="lineNumber">行番号</param>
-  /// <param name="cancellationToken">キャンセレーショントークン</param>
   /// <returns>LogEntry（無効な場合はnull）</returns>
-  private async Task<LogEntry?> ProcessLineAsync(
-      string line,
+  private LogEntry? ProcessLine(
+      ReadOnlySpan<byte> utf8Json,
       string filePath,
-      int lineNumber,
-      CancellationToken cancellationToken)
+      int lineNumber)
   {
+    var reader = new Utf8JsonReader(utf8Json, new JsonReaderOptions
+    {
+      AllowTrailingCommas = _jsonOptions.AllowTrailingCommas,
+      CommentHandling = _jsonOptions.ReadCommentHandling
+    });
+
+    LogEntry entry = new LogEntry();
+    ErrorInfo? errorInfo = null; // ErrorInfo 型に変更、遅延初期化
+
     try
     {
-      cancellationToken.ThrowIfCancellationRequested();
-
-      // UTF-8エンコーディングのバイト配列からの直接デシリアライズは
-      // 大量の行を処理する場合にGCプレッシャーを軽減できる
-      using var jsonDocument = JsonDocument.Parse(line);
-      var entry = jsonDocument.Deserialize<LogEntry>(_jsonOptions);
-
-      if (entry == null)
+      if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
       {
-        _logger.LogWarning("デシリアライズ結果がnullです（行 {LineNumber}）: {Line}", lineNumber, TruncateForLogging(line));
-        return null;
+        throw new JsonException("JSONの開始オブジェクトが見つかりません。");
       }
 
-      // メタデータを設定
-      entry.SourceFile = filePath; // SourceFile はエンコードしない (パス情報のため)
-      entry.ProcessedAt = DateTime.UtcNow;
-
-      // ISO 8601形式の日付が正しく解析されなかった場合の修正処理 (TryParseExactを使用)
-      if (entry.Timestamp == default)
+      while (reader.Read())
       {
-        if (jsonDocument.RootElement.TryGetProperty("timestamp", out var timestampElement) &&
-            timestampElement.ValueKind == JsonValueKind.String)
+        if (reader.TokenType == JsonTokenType.EndObject)
         {
-          var timestampStr = timestampElement.GetString();
-          // ISO 8601 "o" format specifier を使用
-          if (!string.IsNullOrEmpty(timestampStr) &&
-              DateTime.TryParseExact(timestampStr, "o", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsedDate))
+          break; // オブジェクトの終わり
+        }
+
+        if (reader.TokenType != JsonTokenType.PropertyName)
+        {
+          throw new JsonException($"予期しないトークンタイプ: {reader.TokenType}");
+        }
+
+        string propertyName = reader.GetString() ?? throw new JsonException("プロパティ名がnullです。");
+
+        if (!reader.Read()) // プロパティ値へ移動
+        {
+          throw new JsonException($"プロパティ '{propertyName}' の値が見つかりません。");
+        }
+
+        // プロパティ名に基づいて値を設定 (CamelCaseを考慮)
+        // Utf8JsonReader は大文字小文字を区別するため、手動で比較
+        if (string.Equals(propertyName, "id", StringComparison.OrdinalIgnoreCase))
+        {
+          entry.Id = reader.GetString();
+        }
+        else if (string.Equals(propertyName, "timestamp", StringComparison.OrdinalIgnoreCase))
+        {
+          if (reader.TokenType == JsonTokenType.String) // JsonTokenType に修正
           {
-            entry.Timestamp = parsedDate;
+            var timestampStr = reader.GetString();
+            // ISO 8601 "o" format specifier を使用
+            if (!string.IsNullOrEmpty(timestampStr) &&
+                DateTime.TryParseExact(timestampStr, "o", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsedDate))
+            {
+              entry.Timestamp = parsedDate;
+            }
+            else
+            {
+              _logger.LogWarning("ISO 8601 タイムスタンプの解析に失敗しました (行 {LineNumber}): {TimestampString}", lineNumber, timestampStr);
+              // 解析失敗時はデフォルト値(DateTime.MinValue)のまま
+            }
+          }
+          else if (reader.TryGetDateTimeOffset(out var dto)) // DateTimeOffsetも試す
+          {
+            entry.Timestamp = dto.UtcDateTime;
+          }
+          else if (reader.TryGetDateTime(out var dt)) // DateTimeも試す
+          {
+            entry.Timestamp = dt.ToUniversalTime(); // UTCに変換
           }
           else
           {
-            // 解析失敗時のログを追加 (オプション) - 引数の渡し方を修正
-            _logger.LogWarning("ISO 8601 タイムスタンプの解析に失敗しました (行 {LineNumber}): {TimestampString}", lineNumber, timestampStr);
+            _logger.LogWarning("タイムスタンプの解析に失敗しました (行 {LineNumber}): トークンタイプ {TokenType}", lineNumber, reader.TokenType);
           }
+        }
+        else if (string.Equals(propertyName, "level", StringComparison.OrdinalIgnoreCase))
+        {
+          // LogEntry.Level は string 型なので、文字列として読み取る
+          if (reader.TokenType == JsonTokenType.String)
+          {
+            entry.Level = reader.GetString() ?? string.Empty;
+          }
+          else
+          {
+            // 文字列でない場合はログに記録し、デフォルト値(空文字列)のままにするか、エラーとするか検討
+            _logger.LogWarning("ログレベルが文字列ではありません (行 {LineNumber}): トークンタイプ {TokenType}", lineNumber, reader.TokenType);
+            // ここではデフォルト値のまま進める
+            reader.Skip(); // 値をスキップ
+          }
+        }
+        else if (string.Equals(propertyName, "deviceId", StringComparison.OrdinalIgnoreCase))
+        {
+          entry.DeviceId = reader.GetString();
+        }
+        else if (string.Equals(propertyName, "message", StringComparison.OrdinalIgnoreCase))
+        {
+          entry.Message = reader.GetString();
+        }
+        else if (string.Equals(propertyName, "category", StringComparison.OrdinalIgnoreCase))
+        {
+          entry.Category = reader.GetString();
+        }
+        else if (string.Equals(propertyName, "tags", StringComparison.OrdinalIgnoreCase))
+        {
+          if (reader.TokenType == JsonTokenType.StartArray)
+          {
+            var tags = new List<string>();
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+            {
+              if (reader.TokenType == JsonTokenType.String)
+              {
+                tags.Add(reader.GetString() ?? string.Empty);
+              }
+              else
+              {
+                // 配列内の予期しない型はスキップまたはログ記録
+                reader.Skip();
+              }
+            }
+            entry.Tags = tags;
+          }
+          else
+          {
+            reader.Skip(); // 配列でない場合はスキップ
+          }
+        }
+        else if (string.Equals(propertyName, "error", StringComparison.OrdinalIgnoreCase))
+        {
+          if (reader.TokenType == JsonTokenType.StartObject)
+          {
+            errorInfo = new ErrorInfo(); // ErrorInfo に変更、必要になったら初期化
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+            {
+              if (reader.TokenType == JsonTokenType.PropertyName)
+              {
+                string errorPropName = reader.GetString() ?? string.Empty;
+                if (reader.Read()) // 値へ移動
+                {
+                  if (string.Equals(errorPropName, "message", StringComparison.OrdinalIgnoreCase))
+                  {
+                    if (errorInfo != null) errorInfo.Message = reader.GetString(); // null チェック追加
+                  }
+                  else if (string.Equals(errorPropName, "code", StringComparison.OrdinalIgnoreCase))
+                  {
+                    if (errorInfo != null) errorInfo.Code = reader.GetString(); // null チェック追加
+                  }
+                  else if (string.Equals(errorPropName, "stackTrace", StringComparison.OrdinalIgnoreCase))
+                  {
+                    if (errorInfo != null) errorInfo.StackTrace = reader.GetString(); // null チェック追加
+                  }
+                  else
+                  {
+                    reader.Skip(); // 未知のプロパティはスキップ
+                  }
+                }
+              }
+            }
+            entry.Error = errorInfo; // errorInfo を代入
+          }
+          else
+          {
+            reader.Skip(); // オブジェクトでない場合はスキップ
+          }
+        }
+        else
+        {
+          // 未知のプロパティはスキップ
+          reader.Skip();
         }
       }
 
-      // バリデーション
-      var validationResult = await _validator.ValidateAsync(entry, cancellationToken).ConfigureAwait(false);
+      // メタデータを設定
+      entry.SourceFile = filePath;
+      entry.ProcessedAt = DateTime.UtcNow;
+
+      // バリデーション (同期的に実行)
+      // 注意: ValidateAsync を同期的に呼び出すのは理想的ではないが、
+      // IValidator のインターフェースに依存するため、ここでは Task.Run や .Result を使うか、
+      // もしくは IValidator<T> の同期版インターフェースを検討する必要がある。
+      // ここでは簡略化のため .Result を使用するが、デッドロックのリスクがあるため注意。
+      // より安全なのは Validate メソッド (もしあれば) を使うか、非同期コンテキストで実行すること。
+      // 今回は FluentValidation の Validate を使用する。
+      var validationResult = _validator.Validate(entry);
       if (!validationResult.IsValid)
       {
         var errors = string.Join(", ", validationResult.Errors.Select(e => e.ErrorMessage));
@@ -242,7 +380,7 @@ public class JsonLineProcessor
         return null;
       }
 
-      // バリデーション成功後、主要な文字列プロパティをHTMLエンコードする (XSS対策の基本層)
+      // バリデーション成功後、主要な文字列プロパティをHTMLエンコード
       entry.Id = WebUtility.HtmlEncode(entry.Id);
       entry.DeviceId = WebUtility.HtmlEncode(entry.DeviceId);
       entry.Message = WebUtility.HtmlEncode(entry.Message);
@@ -254,28 +392,35 @@ public class JsonLineProcessor
       {
         entry.Tags = entry.Tags.Select(tag => WebUtility.HtmlEncode(tag)).ToList();
       }
-      // entry.SourceFile はファイルパスなのでエンコードしない
+      // entry.Error は ErrorInfo? 型なので null チェックが必要
       if (entry.Error != null)
       {
-        entry.Error.Message = WebUtility.HtmlEncode(entry.Error.Message);
+        // ErrorInfo のプロパティも nullable なので null チェック
+        if (entry.Error.Message != null)
+        {
+          entry.Error.Message = WebUtility.HtmlEncode(entry.Error.Message);
+        }
         if (entry.Error.Code != null)
         {
           entry.Error.Code = WebUtility.HtmlEncode(entry.Error.Code);
         }
-        // StackTrace はエンコードしない方が可読性が高い場合があるため、ここでは除外
+        // StackTrace はエンコードしない
       }
 
       return entry;
     }
-    catch (OperationCanceledException)
+    catch (JsonException ex)
     {
-      // キャンセルは正常な動作として再スロー
-      throw;
+      // JsonException は呼び出し元で処理されるため、ここでは再スローしない
+      // ただし、ログはここで記録してもよい
+      _logger.LogWarning(ex, "JSON解析エラー（行 {LineNumber}）", lineNumber);
+      throw; // 呼び出し元でキャッチしてエラー情報を作成するため再スロー
     }
-    catch (Exception)
+    catch (Exception ex)
     {
-      // その他の例外はこのメソッドの呼び出し元で処理
-      throw;
+      // その他の予期せぬ例外
+      _logger.LogError(ex, "行の処理中に予期せぬエラーが発生しました（行 {LineNumber}）", lineNumber);
+      throw; // 呼び出し元でキャッチしてエラー情報を作成するため再スロー
     }
   }
 


### PR DESCRIPTION
JsonLineProcessor.cs で System.Text.Json.Utf8JsonReader を使用するようにリファクタリングし、パフォーマンスとメモリ効率を改善しました。\n\nFixes #14